### PR TITLE
Set twine username/password directly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,4 +26,4 @@ after_test:
   - cmd: "%PYTHON% -m build"
 
 on_success:
-  - cmd: "%PYTHON% -m twine upload dist\\*"
+  - cmd: "%PYTHON% -m twine upload dist\\* --verbose"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,8 @@
 version: '{build}'
 
 environment:
-  pypipw:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD:
     secure: tTJUexu4V68/Zbl3l/K7x8eI4TR56JZhn2DEvCemP8zNYPCkcFgYfaGp27c6fCoPpgWEvyzJjYyqAzsxLl4mYKtMDEtV9a1B9tD2ElnbERnxpvK4lldg8fAhdpYFw+L3EqPLEaVTAROysUl4w+qf+OQrEet6kcdMGa7jlXSFdqjW/kjU4/SdSD/mQp/Uec4GqcyvxXb8wIm1+tjblFxm9yVh6FfcDdv6/WEm3nWuveUpfQ3yxx6B5RY3SfTySgsS6izSMp//Yqgo5feJ3snv7MzKBezYW90OabQ7Af8o9jY=
 
   matrix:
@@ -22,9 +23,6 @@ artifacts:
   - path: dist\*
 
 after_test:
-  - cmd: "echo [pypi] > %USERPROFILE%\\.pypirc"
-  - cmd: "echo username = __token__ >> %USERPROFILE%\\.pypirc"
-  - cmd: "echo password = %pypipw% >> %USERPROFILE%\\.pypirc"
   - cmd: "%PYTHON% -m build"
 
 on_success:


### PR DESCRIPTION
https://twine.readthedocs.io/en/stable/ says it will read the env variables `TWINE_USERNAME` and `TWINE_PASSWORD` if they're set - use that instead of trying to create a `.pypirc`